### PR TITLE
CI/CD - bug fix with container killing

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -97,7 +97,7 @@ jobs:
           scp -i key.pem -o StrictHostKeyChecking=no dockerhub.yml ubuntu@${{ env.HOST }}:/home/ubuntu/docker-compose.yml
       - name: Prune docker system
         run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker kill $(sudo docker ps -a -q)
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker kill $(sudo docker ps -a -q) || :
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Build
         run: |


### PR DESCRIPTION
## Fix of pull request #5 
Fixed problem with killing all containers it they are not runned in issue #3 . 
Apparently, the command `docker kill $(docker ps -a -q)` fails if there are no active containers.