### PR TITLE
CD - prunning does not work issue

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -93,7 +93,7 @@ jobs:
           chmod 400 key.pem
       - name: Prune docker system
         run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose down || :
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |

--- a/.github/workflows/ci-cd-master.yml
+++ b/.github/workflows/ci-cd-master.yml
@@ -93,7 +93,7 @@ jobs:
           chmod 400 key.pem
       - name: Prune docker system
         run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose down || :
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |


### PR DESCRIPTION
For some reason `sudo docker stop $(sudo docker ps -a -q)` failed to stop all containers. Command `sudo docker ps -a -q` yielded 0 containers. In this fix I used another command `sudo docker-compose down` that does actually the same.