### PR TITLE
CI-CD - fixed error with stopping for both branches

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -91,14 +91,14 @@ jobs:
         run: |
           echo "${{ secrets.SSH_KEY }}" > key.pem
           chmod 400 key.pem
+      - name: Prune docker system
+        run: |
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |
           scp -i key.pem -o StrictHostKeyChecking=no .env ubuntu@${{ env.HOST }}:/home/ubuntu/.env
           scp -i key.pem -o StrictHostKeyChecking=no dockerhub.yml ubuntu@${{ env.HOST }}:/home/ubuntu/docker-compose.yml
-      - name: Prune docker system
-        run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker kill $(sudo docker ps -a -q) || :
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Build
         run: |
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose up -d

--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -93,7 +93,7 @@ jobs:
           chmod 400 key.pem
       - name: Prune docker system
         run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose down || :
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |

--- a/.github/workflows/ci-cd-master.yml
+++ b/.github/workflows/ci-cd-master.yml
@@ -91,14 +91,14 @@ jobs:
         run: |
           echo "${{ secrets.SSH_KEY }}" > key.pem
           chmod 400 key.pem
+      - name: Prune docker system
+        run: |
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |
           scp -i key.pem -o StrictHostKeyChecking=no .env ubuntu@${{ env.HOST }}:/home/ubuntu/.env
           scp -i key.pem -o StrictHostKeyChecking=no dockerhub.yml ubuntu@${{ env.HOST }}:/home/ubuntu/docker-compose.yml
-      - name: Prune docker system
-        run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker kill $(sudo docker ps -a -q) || :
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Build
         run: |
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose up -d

--- a/.github/workflows/ci-cd-master.yml
+++ b/.github/workflows/ci-cd-master.yml
@@ -93,7 +93,7 @@ jobs:
           chmod 400 key.pem
       - name: Prune docker system
         run: |
-          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker stop $(sudo docker ps -a -q) || :
+          ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker-compose down || :
           ssh -i key.pem -o StrictHostKeyChecking=no ubuntu@${{ env.HOST }} sudo docker system prune -a --volumes -f
       - name: Transfer files to remote host
         run: |


### PR DESCRIPTION
Fixed issues mentioned in pull request #12 for both branches.
> For some reason `sudo docker stop $(sudo docker ps -a -q)` failed to stop all containers. Command `sudo docker ps -a -q` yielded 0 containers. In this fix I used another command `sudo docker-compose down` that does actually the same.