### PR TITLE
CI/CD - slim for docker

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Run Postgre SQL container
         run: |
           docker-compose -f database.yml up -d
+          sleep 5
       - name: Make migrations
         run: |
           python ./backend/manage.py makemigrations

--- a/.github/workflows/ci-cd-master.yml
+++ b/.github/workflows/ci-cd-master.yml
@@ -48,6 +48,7 @@ jobs:
       - name: Run Postgre SQL container
         run: |
           docker-compose -f database.yml up -d
+          sleep 5
       - name: Make migrations
         run: |
           python ./backend/manage.py makemigrations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.8.10-alpine
+FROM python:3.8-slim
 
 RUN pip install --upgrade pip
-
-RUN apk update && apk add postgresql-dev gcc python3-dev musl-dev
 
 COPY ./requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
It turned out that `pandas` package cannot be properly installed on `alpine` image. Changed image to `slim`.
On the CI stage added delay after Postgre SQL container creation. The problem occured in workflow, when database restarted unexpectedly for application. In fact, this is the part of database starting routine and cannot be eliminated. Still the delay should work.