### PR TITLE
DTO - fixed Option's constraints

### DIFF
--- a/backend/risk_factors/models.py
+++ b/backend/risk_factors/models.py
@@ -43,7 +43,7 @@ class Option(models.Model):
     question = models.ForeignKey(Question,
                                  on_delete=models.CASCADE,
                                  related_name="options")
-    answer = models.CharField(max_length=1000, unique=True)
+    answer = models.CharField(max_length=1000)
 
     def __str__(self):
         return self.answer


### PR DESCRIPTION
There was bug with `unique` constraint for field answer. Several options contained `Yes` answer, and it yilded following problem:
`django.db.utils.IntegrityError: duplicate key value violates unique constraint "risk_factors_option_answer_key"`. Issue is fixed by eleminating this constraint.