### PR TITLE
CORS 

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
 ]
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
+    'django.middleware.common.CommonMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -51,7 +52,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.common.CommonMiddleware',
 ]
 
 ROOT_URLCONF = 'backend.urls'
@@ -128,6 +128,7 @@ USE_TZ = True
 
 STATIC_ROOT = '/static/'
 STATIC_URL = '/static/'
+
 CORS_ORIGIN_ALLOW_ALL = True
 
 # Default primary key field type


### PR DESCRIPTION
## Issue #39 
As mentioned in this issue, requests from web frontend fails because of CORS. It seems that this is because of position of common middleware in list of middlewares.  